### PR TITLE
feat: add option to extend special tokens and to provide custom ranks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ wasm-bindgen = "0.2.83"
 js-sys = "0.3.61"
 anyhow = "1.0.69"
 base64 = "0.21.0"
+gloo-utils = { version = "0.1", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
 
 # tiktoken dependencies
 fancy-regex = "0.10.0"
@@ -23,3 +25,7 @@ bstr = "1.0.1"
 [profile.release]
 incremental = true
 opt-level = "s"
+
+[features]
+default = ["inline"]
+inline = []


### PR DESCRIPTION
This PR implements the following features:

_Creating custom encoders_

```typescript
import { readFileSync } from "fs";

const encoder = new Tiktoken(
  readFileSync("./ranks/gpt2.tiktoken").toString("utf-8"),
  { "<|endoftext|>": 50256, "<|im_start|>": 100264, "<|im_end|>": 100265 },
  "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)|\\s+"
);
```

_Extending existing encoders with additional special tokens_
```typescript
const encoder = encoding_for_model("gpt2", {
  "<|im_start|>": 100264,
  "<|im_end|>": 100265,
})
```

Closes #1