### PR TITLE
add `gpt-3.5-turbo`(chatGPT) to model-to-encodings

### DIFF
--- a/tiktoken/model_to_encoding.json
+++ b/tiktoken/model_to_encoding.json
@@ -28,5 +28,6 @@
     "text-search-ada-doc-001": "r50k_base",
     "code-search-babbage-code-001": "r50k_base",
     "code-search-ada-code-001": "r50k_base",
-    "gpt2": "gpt2"
+    "gpt2": "gpt2",
+    "gpt-3.5-turbo": "cl100k_base"
 }


### PR DESCRIPTION
The model_to_encoding information for chatGPT was missing, so I added.  Please refer to this issue. 
https://github.com/openai/tiktoken/issues/42