### PR TITLE
Remove prefix from folder

### DIFF
--- a/.changeset/rude-candles-dress.md
+++ b/.changeset/rude-candles-dress.md
@@ -1,0 +1,5 @@
+---
+"tiktoken": patch
+---
+
+Fix invalid prefix for resolving broken resolution

--- a/wasm/scripts/postprocess.ts
+++ b/wasm/scripts/postprocess.ts
@@ -174,7 +174,6 @@ for (const baseDir of [
                 path.join(
                   prefix,
                   "node_modules",
-                  "@dqbd",
                   "tiktoken",
                   "${relativeDir}",
                   "./tiktoken_bg.wasm"


### PR DESCRIPTION
Closes When running 1.0.9 there is a Missing tiktoken_bg.wasm error dqbd/tiktoken#56