### PR TITLE
Add new models

### DIFF
--- a/js/src/core.ts
+++ b/js/src/core.ts
@@ -264,6 +264,9 @@ export function getEncodingNameForModel(model: TiktokenModel) {
     case "gpt-35-turbo":
     case "gpt-4-1106-preview":
     case "gpt-4-vision-preview":
+    case "gpt-3.5-turbo-0125":
+    case "gpt-4-turbo-preview":
+    case "gpt-4-0125-preview":
     case "text-embedding-ada-002": {
       return "cl100k_base";
     }

--- a/tiktoken/model_to_encoding.json
+++ b/tiktoken/model_to_encoding.json
@@ -36,6 +36,7 @@
     "gpt-3.5-turbo-0301": "cl100k_base",
     "gpt-3.5-turbo-0613": "cl100k_base",
     "gpt-3.5-turbo-1106": "cl100k_base",
+    "gpt-3.5-turbo-0125": "cl100k_base",
     "gpt-3.5-turbo-16k": "cl100k_base",
     "gpt-3.5-turbo-16k-0613": "cl100k_base",
     "gpt-4": "cl100k_base",
@@ -44,6 +45,8 @@
     "gpt-4-32k": "cl100k_base",
     "gpt-4-32k-0314": "cl100k_base",
     "gpt-4-32k-0613": "cl100k_base",
+    "gpt-4-turbo-preview": "cl100k_base",
     "gpt-4-1106-preview": "cl100k_base",
+    "gpt-4-0125-preview": "cl100k_base",
     "gpt-4-vision-preview": "cl100k_base"
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -393,9 +393,12 @@ export type TiktokenModel =
     | "gpt-3.5-turbo-0301"
     | "gpt-3.5-turbo-0613"
     | "gpt-3.5-turbo-1106"
+    | "gpt-3.5-turbo-0125"
     | "gpt-3.5-turbo-16k"
     | "gpt-3.5-turbo-16k-0613"
+    | "gpt-4-turbo-preview"
     | "gpt-4-1106-preview"
+    | "gpt-4-0125-preview"
     | "gpt-4-vision-preview"
 
 /**
@@ -460,6 +463,9 @@ pub fn encoding_for_model(
         "gpt-35-turbo" => Ok("cl100k_base"),
         "gpt-4-1106-preview" => Ok("cl100k_base"),
         "gpt-4-vision-preview" => Ok("cl100k_base"),
+        "gpt-3.5-turbo-0125" => Ok("cl100k_base"),
+        "gpt-4-turbo-preview" => Ok("cl100k_base"),
+        "gpt-4-0125-preview" => Ok("cl100k_base"),
         model => Err(JsError::new(
             format!("Invalid model: {}", model.to_string()).as_str(),
         )),


### PR DESCRIPTION
Adds new models released on January 25th, 2024.

- gpt-3.5-turbo-0125
- gpt-4-turbo-preview (alias)
- gpt-4-0125-preview

The encodings are based on the definitions in [`model.py`](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py).

The following models are also added, but this PR does not include them.
The encodings are still unknown since [openai/tiktoken](https://github.com/openai/tiktoken) is not updated yet.

- text-embedding-3-large
- text-embedding-3-small
- text-moderation-007
- text-moderation-latest (alias)
- text-moderation-stable (alias)

OpenAI blog post: [New embedding models and API updates](https://openai.com/blog/new-embedding-models-and-api-updates)
OpenAI API: [Models](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo)