### PR TITLE
Add support for new text-embedding-3 models

### DIFF
--- a/tiktoken/model_to_encoding.json
+++ b/tiktoken/model_to_encoding.json
@@ -20,6 +20,8 @@
     "text-davinci-edit-001": "p50k_edit",
     "code-davinci-edit-001": "p50k_edit",
     "text-embedding-ada-002": "cl100k_base",
+    "text-embedding-3-small": "cl100k_base",
+    "text-embedding-3-large": "cl100k_base",
     "text-similarity-davinci-001": "r50k_base",
     "text-similarity-curie-001": "r50k_base",
     "text-similarity-babbage-001": "r50k_base",


### PR DESCRIPTION
`text-embedding-3-large` and `text-embedding-3-small` aren't supported in `js-tiktoken`.
All we have to do is to add them to the config, like it's in the [original tiktoken repo](https://github.com/openai/tiktoken/blob/c0ba74c238d18b4824c25f3c27fc8698055b9a76/tiktoken/model.py#L33).