### PR TITLE
Add new model support to js

### DIFF
--- a/js/src/core.ts
+++ b/js/src/core.ts
@@ -293,6 +293,9 @@ export function getEncodingNameForModel(model: TiktokenModel) {
     case "chatgpt-4o-latest":
     case "gpt-4o-realtime":
     case "gpt-4o-realtime-preview-2024-10-01":
+    case "gpt-4.1-2025-04-14":
+    case "gpt-4.1-mini-2025-04-14":
+    case "gpt-4.1-nano-2025-04-14":
     {
       return "o200k_base";
     }


### PR DESCRIPTION
OpenAI recently released new models and during testing the function `getEncodingNameForModel` throws an error for the new OpenAI models of the 4.1 family. 

Added to the switch case to use the new models, which returns the `"o200k_base"`.

It is small error that is thrown in my codebase.

Fixes: #139 